### PR TITLE
FIX: 메인 탭별 에러사항 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,6 +29,7 @@ const nextConfig = {
       'cdn.hkbs.co.kr',
       'cdn.esgeconomy.com',
       'www.gravatar.com',
+      'relogging.s3.ap-northeast-2.amazonaws.com',
     ], // 허용할 도메인 목록을 지정
     remotePatterns: [
       {

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -212,8 +212,8 @@ export default function EventDetailPage() {
         {/* 오른쪽 사이드바 */}
         <div className="hidden min-w-0 laptop:block laptop:flex-[4]">
           <ContentList
-            contentData={eventsList?.content}
-            totalPage={eventsList?.totalPages}
+            contentData={eventsList?.content ?? []}
+            totalPage={eventsList?.totalPages ?? 0}
             currentPage={currentPage}
             handlePageChange={handlePageChange}
             cotentListIsLoading={eventsListIsLoading}

--- a/src/app/meetup/[id]/page.tsx
+++ b/src/app/meetup/[id]/page.tsx
@@ -11,7 +11,7 @@ import { ErrorAlert } from '@/components/status/ErrorAlert'
 import { LoadingSkeleton } from '@/components/status/LoadingSkeleton'
 import ContentList from '@/components/ContentList'
 import { useMeetupQueries } from '@/hooks/useMeetupList'
-import { MeetupDetailSectionProps, MeetupDetailType } from '@/types/IMeetup'
+import { IMeetupDetailSectionProps, MeetupDetailType } from '@/types/IMeetup'
 import { DEFAULT_IMAGE } from '@/types/INews'
 
 const MeetupDetailSection = ({
@@ -20,7 +20,7 @@ const MeetupDetailSection = ({
   isError,
   error,
   handleMeetupChange,
-}: MeetupDetailSectionProps) => {
+}: IMeetupDetailSectionProps) => {
   if (isLoading) {
     return (
       <section className="flex flex-[8] flex-col gap-10 md:col-span-6">
@@ -84,39 +84,22 @@ const MeetupDetailSection = ({
             label="참여기간"
             content={`${meetupDetail.startDate} - ${meetupDetail.endDate}`}
           />
-          <LabeledContent
-            label="참여대상"
-            content={`${meetupDetail?.participantTarget}`}
-          />
+
           <LabeledContent
             label="참여장소"
             content={meetupDetail?.location ?? '-'}
           />
-          <LabeledContent
-            label="지원내용"
-            content={meetupDetail?.supportDetails ?? '-'}
-          />
+
           <LabeledContent label="봉사점수" content="0.5시간" />
           <LabeledContent
             label="참여방법"
             content="양재천 ~ 양재천 일대를 걸으며 쓰레기(플로깅)"
-          />
-          <LabeledContent
-            label="연락처"
-            content={meetupDetail?.contactNumber ?? '-'}
-          />
-          <LabeledContent
-            label="연락 방법"
-            content={meetupDetail?.registrationLink ?? '-'}
           />
         </div>
         <div className="prose max-w-none space-y-4 text-sm">
           <span className="border-green- whitespace-nowrap rounded-md border bg-green p-1 text-xs font-semibold text-white">
             상세내용
           </span>
-          <p className="mb-4 text-xs text-text">
-            {meetupDetail?.content ?? '-'}
-          </p>
         </div>
       </div>
       <div className="flex items-center justify-between">
@@ -209,8 +192,8 @@ export default function MeetupDetailPage() {
         {/* 오른쪽 사이드바 */}
         <div className="hidden min-w-0 laptop:block laptop:flex-[4]">
           <ContentList
-            contentData={meetupList?.content}
-            totalPage={meetupList?.totalPages}
+            contentData={meetupList?.ploggingMeetupSimpleResponseList ?? []}
+            totalPage={meetupList?.totalPage ?? 0}
             currentPage={currentPage}
             handlePageChange={handlePageChange}
             cotentListIsLoading={meetupListIsLoading}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import EventListGrid from '@/components/EventListGrid'
-import NewsListGrid from '@/components/NewsListGrid'
-import { useState } from 'react'
 import Image from 'next/image'
 import Footer from '@/components/layouts/Footer'
+import { useRouter, useSearchParams } from 'next/navigation'
 import MeetupList from '@/components/MeetupList'
+import EventListGrid from '@/components/EventListGrid'
+import NewsListGrid from '@/components/NewsListGrid'
 
 const images = {
   mobile: {
@@ -26,8 +26,31 @@ const images = {
 } as const
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState('우리 동네 플로깅')
-  // max-w-[1440px]
+  const router = useRouter()
+  const searchParms = useSearchParams()
+  const currentTab = searchParms.get('tab') || 'ploggingEvent'
+  const tabList = [
+    { id: 'ploggingEvent', label: '우리 동네 플로깅' },
+    { id: 'meetup', label: '플로깅 모임' },
+    { id: 'news', label: '뉴스' },
+  ]
+
+  const handleTabChange = (tabId: string) => {
+    router.push(`/?tab=${tabId}`)
+  }
+
+  const renderContent = () => {
+    switch (currentTab) {
+      case 'ploggingEvent':
+        return <EventListGrid />
+      case 'news':
+        return <NewsListGrid />
+      case 'meetup':
+        return <MeetupList />
+      default:
+        return <EventListGrid />
+    }
+  }
   return (
     <div className="h-full w-full bg-background">
       <section className="margin-auto hidden w-dvw laptop:block">
@@ -66,44 +89,24 @@ export default function Home() {
           {/* 탭 섹션 */}
           <div className="rounded-lg bg-white p-5 shadow laptop:p-10">
             <div className="mb-4 flex border-b border-gray-200">
-              <button
-                className={`block px-6 py-4 text-gray-600 hover:text-textLight focus:outline-none ${
-                  activeTab === '우리 동네 플로깅'
-                    ? 'border-b-2 border-text font-medium text-blue-500'
-                    : ''
-                }`}
-                onClick={() => setActiveTab('우리 동네 플로깅')}
-              >
-                우리 동네 플로깅
-              </button>
-              <button
-                className={`block px-6 py-4 text-gray-600 hover:text-textLight focus:outline-none ${
-                  activeTab === '플로깅 모임'
-                    ? 'border-b-2 border-text font-medium text-blue-500'
-                    : ''
-                }`}
-                onClick={() => setActiveTab('플로깅 모임')}
-              >
-                플로깅 모임
-              </button>
-              <button
-                className={`block px-6 py-4 text-gray-600 hover:text-textLight focus:outline-none ${
-                  activeTab === '환경 뉴스'
-                    ? 'border-b-2 border-text font-medium text-blue-500'
-                    : ''
-                }`}
-                onClick={() => setActiveTab('환경 뉴스')}
-              >
-                환경 뉴스
-              </button>
+              {tabList.map((tab) => {
+                return (
+                  <button
+                    key={tab.id}
+                    className={`block px-6 py-4 text-gray-600 hover:text-textLight ${
+                      tab.id === currentTab
+                        ? 'border-b-2 border-green font-medium text-text'
+                        : ''
+                    }`}
+                    onClick={() => handleTabChange(tab.id)}
+                  >
+                    {tab.label}
+                  </button>
+                )
+              })}
             </div>
-            {/* 우리동네 플로깅 그리드 */}
-            {activeTab === '우리 동네 플로깅' && <EventListGrid />}
-            {/* 플로깅 모임 그리드 */}
-            {activeTab === '플로깅 모임' && <MeetupList />}
-            {/* 뉴스 그리드 */}
-            {activeTab === '환경 뉴스' && <NewsListGrid />}
-            {/* )} */}
+            {/* 콘텐츠 섹션 */}
+            {renderContent()}
           </div>
         </main>
       </div>

--- a/src/components/ContentList.tsx
+++ b/src/components/ContentList.tsx
@@ -2,14 +2,17 @@ import { NewsArticleCard } from '@/types/INews'
 import { ContentsPagination } from './ContentsPagination'
 import NewsCard from './NewsCard'
 import { EventCard } from './EventCard'
-import { EventContentCard } from '@/types/IEvent'
+import { IEventContentCard } from '@/types/IEvent'
 import { LoadingSkeleton } from './status/LoadingSkeleton'
 import { ErrorAlert } from './status/ErrorAlert'
 import { EmptyState } from './status/EmptyStatus'
 import { MeetupCard } from './MeetupCard'
-import { MeetupContentCard } from '@/types/IMeetup'
+import { IMeetupContentCard } from '@/types/IMeetup'
 
-export type ContentType = NewsArticleCard | EventContentCard | MeetupContentCard
+export type ContentType =
+  | NewsArticleCard
+  | IEventContentCard
+  | IMeetupContentCard
 export type EventType = 'news' | 'events' | 'meetup'
 interface IContentList {
   contentData: ContentType[]
@@ -28,9 +31,11 @@ const contentTemplate = (item: ContentType, type: EventType) => {
     case 'news':
       return <NewsCard article={item as NewsArticleCard} key={item.id} />
     case 'events':
-      return <EventCard eventData={item as EventContentCard} key={item.id} />
+      return <EventCard eventData={item as IEventContentCard} key={item.id} />
     case 'meetup':
-      return <MeetupCard meetupData={item as MeetupContentCard} key={item.id} />
+      return (
+        <MeetupCard meetupData={item as IMeetupContentCard} key={item.id} />
+      )
     default:
       return null
   }

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,11 +1,11 @@
-import { EventContentCard } from '@/types/IEvent'
+import { IEventContentCard } from '@/types/IEvent'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { Card } from '@/components/ui/card'
 import { MapPin, Clock } from 'lucide-react'
 import { DEFAULT_IMAGE } from '@/types/INews'
 
-export const EventCard = ({ eventData }: { eventData: EventContentCard }) => {
+export const EventCard = ({ eventData }: { eventData: IEventContentCard }) => {
   const router = useRouter()
 
   const onClickEventDetail = (id: string) => {

--- a/src/components/EventListGrid.tsx
+++ b/src/components/EventListGrid.tsx
@@ -1,16 +1,37 @@
 import { useState } from 'react'
 import { useEventsQueries } from '@/hooks/useEventsQueries'
 import ContentList from './ContentList'
+import { ErrorAlert } from './status/ErrorAlert'
+import { LoadingSkeleton } from './status/LoadingSkeleton'
+import { EmptyState } from './status/EmptyStatus'
 
 export default function EventListGrid() {
   const [currentPage, setCurrentPage] = useState(0) // 초기 페이지 1번으로 설정
   const pageSize = 15 // 페이지 당 아이템 수
 
-  const { eventsList, eventsListIsLoading, eventListIsError } =
+  const { eventsList, eventsListIsLoading, eventListIsError, evnetListError } =
     useEventsQueries({ currentPage, pageSize })
 
   const handlePageChange = async (newPage: number) => {
     setCurrentPage(newPage)
+  }
+
+  if (eventsListIsLoading) return <LoadingSkeleton />
+  if (evnetListError || !eventsList || eventListIsError) {
+    return (
+      <ErrorAlert
+        error={evnetListError?.message || '데이터를 불러오는데 실패했습니다'}
+      />
+    )
+  }
+
+  if (eventsList.content.length === 0) {
+    return (
+      <EmptyState
+        title="동네 플로깅이 없습니다"
+        description="현재 우리 동네 플로깅이 없습니다."
+      />
+    )
   }
 
   return (

--- a/src/components/MeetupCard.tsx
+++ b/src/components/MeetupCard.tsx
@@ -3,12 +3,12 @@ import { useRouter } from 'next/navigation'
 import { Card } from '@/components/ui/card'
 import { MapPin, Clock } from 'lucide-react'
 import { DEFAULT_IMAGE } from '@/types/INews'
-import { MeetupContentCard } from '@/types/IMeetup'
+import { IMeetupContentCard } from '@/types/IMeetup'
 
 export const MeetupCard = ({
   meetupData,
 }: {
-  meetupData: MeetupContentCard
+  meetupData: IMeetupContentCard
 }) => {
   const router = useRouter()
 
@@ -63,6 +63,16 @@ export const MeetupCard = ({
             </div>
             <span className="text-sm text-gray-400">
               조회수 {meetupData.hits}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between gap-2 text-text">
+            <div className="flex gap-2">
+              <MapPin className="h-4 w-4" />
+              {/* <span className="text-sm"> {meetupData.location}</span> */}
+            </div>
+            <span className="text-sm text-gray-400">
+              활동시간 {meetupData.activityHours}
             </span>
           </div>
 

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -1,23 +1,47 @@
 import { useState } from 'react'
 import ContentList from './ContentList'
 import { useMeetupQueries } from '@/hooks/useMeetupList'
+import { EmptyState } from './status/EmptyStatus'
+import { ErrorAlert } from './status/ErrorAlert'
+import { LoadingSkeleton } from './status/LoadingSkeleton'
 
 export default function MeetupList() {
   const [currentPage, setCurrentPage] = useState(0) // 초기 페이지 1번으로 설정
   const pageSize = 15 // 페이지 당 아이템 수
 
-  const { meetupList, meetupListIsLoading, meetupListIsError } =
-    useMeetupQueries({ currentPage, pageSize })
+  const {
+    meetupList,
+    meetupListIsLoading,
+    meetupListIsError,
+    meetupListError,
+  } = useMeetupQueries({ currentPage, pageSize })
 
   const handlePageChange = async (newPage: number) => {
     setCurrentPage(newPage)
   }
 
+  if (meetupListIsLoading) return <LoadingSkeleton />
+  if (meetupListError || !meetupList || meetupListIsError) {
+    return (
+      <ErrorAlert
+        error={meetupListError?.message || '데이터를 불러오는데 실패했습니다'}
+      />
+    )
+  }
+  if (meetupList.ploggingMeetupSimpleResponseList.length === 0) {
+    return (
+      <EmptyState
+        title="플로깅 모임이 없습니다"
+        description="현재 플로깅 모임이 없습니다."
+      />
+    )
+  }
+
   return (
     <>
       <ContentList
-        contentData={meetupList?.content}
-        totalPage={meetupList?.totalPages}
+        contentData={meetupList?.ploggingMeetupSimpleResponseList}
+        totalPage={meetupList?.totalPage}
         currentPage={currentPage}
         handlePageChange={handlePageChange}
         cotentListIsLoading={meetupListIsLoading}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,6 +1,6 @@
-"use client"
+'use client'
 
-import { useToast } from "@/hooks/use-toast"
+import { useToast } from '@/hooks/use-toast'
 import {
   Toast,
   ToastClose,
@@ -8,7 +8,7 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/ui/toast"
+} from '@/components/ui/toast'
 
 export function Toaster() {
   const { toasts } = useToast()

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,12 +1,10 @@
-"use client"
+'use client'
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 // Inspired by react-hot-toast library
-import * as React from "react"
+import * as React from 'react'
 
-import type {
-  ToastActionElement,
-  ToastProps,
-} from "@/components/ui/toast"
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast'
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
@@ -19,10 +17,10 @@ type ToasterToast = ToastProps & {
 }
 
 const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
 } as const
 
 let count = 0
@@ -36,20 +34,20 @@ type ActionType = typeof actionTypes
 
 type Action =
   | {
-      type: ActionType["ADD_TOAST"]
+      type: ActionType['ADD_TOAST']
       toast: ToasterToast
     }
   | {
-      type: ActionType["UPDATE_TOAST"]
+      type: ActionType['UPDATE_TOAST']
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType["DISMISS_TOAST"]
-      toastId?: ToasterToast["id"]
+      type: ActionType['DISMISS_TOAST']
+      toastId?: ToasterToast['id']
     }
   | {
-      type: ActionType["REMOVE_TOAST"]
-      toastId?: ToasterToast["id"]
+      type: ActionType['REMOVE_TOAST']
+      toastId?: ToasterToast['id']
     }
 
 interface State {
@@ -66,7 +64,7 @@ const addToRemoveQueue = (toastId: string) => {
   const timeout = setTimeout(() => {
     toastTimeouts.delete(toastId)
     dispatch({
-      type: "REMOVE_TOAST",
+      type: 'REMOVE_TOAST',
       toastId: toastId,
     })
   }, TOAST_REMOVE_DELAY)
@@ -76,21 +74,21 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case 'ADD_TOAST':
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       }
 
-    case "UPDATE_TOAST":
+    case 'UPDATE_TOAST':
       return {
         ...state,
         toasts: state.toasts.map((t) =>
-          t.id === action.toast.id ? { ...t, ...action.toast } : t
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
         ),
       }
 
-    case "DISMISS_TOAST": {
+    case 'DISMISS_TOAST': {
       const { toastId } = action
 
       // ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -111,11 +109,11 @@ export const reducer = (state: State, action: Action): State => {
                 ...t,
                 open: false,
               }
-            : t
+            : t,
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case 'REMOVE_TOAST':
       if (action.toastId === undefined) {
         return {
           ...state,
@@ -140,20 +138,20 @@ function dispatch(action: Action) {
   })
 }
 
-type Toast = Omit<ToasterToast, "id">
+type Toast = Omit<ToasterToast, 'id'>
 
 function toast({ ...props }: Toast) {
   const id = genId()
 
   const update = (props: ToasterToast) =>
     dispatch({
-      type: "UPDATE_TOAST",
+      type: 'UPDATE_TOAST',
       toast: { ...props, id },
     })
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id })
 
   dispatch({
-    type: "ADD_TOAST",
+    type: 'ADD_TOAST',
     toast: {
       ...props,
       id,
@@ -187,7 +185,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
   }
 }
 

--- a/src/hooks/useContentList.ts
+++ b/src/hooks/useContentList.ts
@@ -1,4 +1,4 @@
-import { EventContentCard } from '@/types/IEvent'
+import { IEventContentCard } from '@/types/IEvent'
 import { NewsArticleCard } from '@/types/INews'
 import { useQuery } from '@tanstack/react-query'
 import { fetchNewsLists } from './useNewsQueries'
@@ -36,7 +36,7 @@ const fetchStrategies = {
   },
 }
 
-export function useContentList<T extends NewsArticleCard | EventContentCard>({
+export function useContentList<T extends NewsArticleCard | IEventContentCard>({
   contentType,
   currentPage,
   pageSize,

--- a/src/hooks/useEventsQueries.ts
+++ b/src/hooks/useEventsQueries.ts
@@ -1,11 +1,6 @@
+import { IEventsQueries, IPloggingEventContentList } from '@/types/IEvent'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
-
-interface IEventsQueries {
-  currentPage?: number
-  pageSize?: number
-  eventId?: string
-}
 
 export async function fetchEventsArticle(page: number, size: number) {
   const params = new URLSearchParams()
@@ -47,14 +42,19 @@ export const useEventsQueries = ({
   const queryClient = useQueryClient()
   const router = useRouter()
 
-  const eventsListQuery = useQuery({
+  const eventsListQuery = useQuery<IPloggingEventContentList>({
     queryKey: ['eventsList', currentPage, pageSize],
     queryFn: () => fetchEventsArticle(currentPage ?? 0, pageSize ?? 15),
+    staleTime: 5 * 60 * 1000, // 데이터가 "신선"하다고 간주되는 시간 (5분)
+    gcTime: 30 * 60 * 1000, // 데이터가 캐시에 유지되는 시간 (30분)
   })
 
   const eventDetailQuery = useQuery({
     queryKey: ['eventDetail', eventId],
     queryFn: () => fetchEventDetail(eventId ?? ''),
+    enabled: !!eventId,
+    staleTime: 5 * 60 * 1000, // 데이터가 "신선"하다고 간주되는 시간 (5분)
+    gcTime: 30 * 60 * 1000, // 데이터가 캐시에 유지되는 시간 (30분)
   })
 
   // 이전/다음 이벤트 네비게이션

--- a/src/hooks/useMeetupList.ts
+++ b/src/hooks/useMeetupList.ts
@@ -1,11 +1,6 @@
+import { IMeetupListResponse, ImeetupQueries } from '@/types/IMeetup'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
-
-interface ImeetupQueries {
-  currentPage?: number
-  pageSize?: number
-  meetupId?: string
-}
 
 export async function fetchMeetupingArticle(page: number, size: number) {
   const params = new URLSearchParams()
@@ -47,7 +42,7 @@ export const useMeetupQueries = ({
   const queryClient = useQueryClient()
   const router = useRouter()
 
-  const meetupListQuery = useQuery({
+  const meetupListQuery = useQuery<IMeetupListResponse>({
     queryKey: ['meetupList', currentPage, pageSize],
     queryFn: () => fetchMeetupingArticle(currentPage ?? 0, pageSize ?? 15),
   })
@@ -55,6 +50,7 @@ export const useMeetupQueries = ({
   const meetupDetailQuery = useQuery({
     queryKey: ['meetupDetail', meetupId],
     queryFn: () => fetchMeetupDetail(meetupId ?? ''),
+    enabled: !!meetupId,
   })
 
   // 이전/다음 이벤트 네비게이션

--- a/src/hooks/useNewsQueries.ts
+++ b/src/hooks/useNewsQueries.ts
@@ -48,6 +48,7 @@ export const useNewsQueries = ({
   const newsDetailQuery = useQuery({
     queryKey: ['newsDetail', articleId],
     queryFn: () => fetchNewsArticle(articleId ?? ''),
+    enabled: !!articleId,
     staleTime: 5 * 60 * 1000, // 데이터가 "신선"하다고 간주되는 시간 (5분)
     gcTime: 30 * 60 * 1000, // 데이터가 캐시에 유지되는 시간 (30분)
   })

--- a/src/types/IEvent.ts
+++ b/src/types/IEvent.ts
@@ -1,5 +1,11 @@
+export interface IEventsQueries {
+  currentPage?: number
+  pageSize?: number
+  eventId?: string
+}
+
 // 개별 플로깅 이벤트 타입 정의
-export interface EventContentCard {
+export interface IEventContentCard {
   id: string
   title: string
   location: string
@@ -11,7 +17,31 @@ export interface EventContentCard {
   caption: string
 }
 
-// 컨텐츠 배열 타입 정의
-export interface PloggingEventContentList {
-  content: EventContentCard[]
+export interface IPageable {
+  pageNumber: number
+  pageSize: number
+  sort: ISort
+  offset: number
+  paged: boolean
+  unpaged: boolean
+}
+
+export interface ISort {
+  empty: boolean
+  sorted: boolean
+  unsorted: boolean
+}
+
+export interface IPloggingEventContentList {
+  content: IEventContentCard[]
+  pageable: IPageable
+  totalPages: number
+  totalElements: number
+  last: boolean
+  size: number
+  number: number
+  sort: ISort
+  numberOfElements: number
+  first: boolean
+  empty: boolean
 }

--- a/src/types/IMeetup.ts
+++ b/src/types/IMeetup.ts
@@ -1,33 +1,38 @@
 export type MeetupDetailType = 'prev' | 'next'
 
 // MeetupDetailSection의 props 타입 정의
-export interface MeetupDetailSectionProps {
-  meetupDetail: MeetupContentCard | null // null 포함하여 데이터가 없을 경우 대비
+export interface IMeetupDetailSectionProps {
+  meetupDetail: IMeetupContentCard | null // null 포함하여 데이터가 없을 경우 대비
   isLoading: boolean
   isError: boolean
   error: Error | null
   handleMeetupChange: (type: MeetupDetailType) => void
 }
 
-export interface MeetupContentCard {
+export interface ImeetupQueries {
+  currentPage?: number
+  pageSize?: number
+  meetupId?: string
+}
+export interface IMeetupContentCard {
   id: number
   title: string
-  location: string
   region: string
-  content: string
-  hits: number
+  location: string
   startDate: string
   endDate: string
-  participantTarget?: string
-  supportDetails?: string
-  activityHours?: string
-  contactPerson: string
-  contactNumber: string
-  registrationLink?: string
   imageUrl: string
+  activityHours: string
+  hits: number
 }
 
 // 컨텐츠 배열 타입 정의
-export interface PloggingMeetupList {
-  content: MeetupContentCard[]
+export interface IPloggingMeetupList {
+  content: IMeetupContentCard[]
+}
+
+export interface IMeetupListResponse {
+  totalPage: number
+  totalElements: number
+  ploggingMeetupSimpleResponseList: IMeetupContentCard[]
 }


### PR DESCRIPTION
Close #81

## #️⃣연관된 이슈

> #81

## 📝작업 내용

> 탭별로 쿼리 스트링 추가해 새로고침 및 뒤로가기 해도 이전 상태 유지 및 리스트 요청 및 디테일 페이지 요청 중복으로 날라가던 사항 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
